### PR TITLE
Add GH Pages deployment for WASM DXF viewer

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy WASM demo to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "wasm/**"
+      - "Makefile"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/gh-pages.yml"
+      - "dxf/**"
+      - "jww/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build WebAssembly assets
+        run: make dist
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-wasm test stat clean convert-examples clean-bin clean-dist clean-converted
+.PHONY: build build-wasm test stat clean convert-examples clean-bin clean-dist clean-converted copy-wasm-assets
 
 # Build native binary
 build: clean-bin
@@ -15,10 +15,21 @@ build-wasm: clean-dist
 
 # Copy wasm_exec.js from Go installation
 copy-wasm-exec:
-	cp "$$(go env GOROOT)/misc/wasm/wasm_exec.js" dist/
+	mkdir -p dist
+	if [ -f "$$(go env GOROOT)/misc/wasm/wasm_exec.js" ]; then \
+		cp "$$(go env GOROOT)/misc/wasm/wasm_exec.js" dist/; \
+	else \
+		cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" dist/; \
+	fi
+
+# Copy static assets for the WASM demo
+copy-wasm-assets:
+	mkdir -p dist
+	cp wasm/example.html dist/index.html
+	cp wasm/styles.css wasm/app.js dist/
 
 # Build WASM and copy support files
-dist: build-wasm copy-wasm-exec
+dist: build-wasm copy-wasm-exec copy-wasm-assets
 
 # Run tests
 test:

--- a/wasm/app.js
+++ b/wasm/app.js
@@ -1,0 +1,158 @@
+(() => {
+    const elements = {
+        fileInput: document.getElementById("fileInput"),
+        fileLabel: document.getElementById("fileLabel"),
+        convertBtn: document.getElementById("convertBtn"),
+        status: document.getElementById("status"),
+        meta: document.getElementById("meta"),
+        dxfOutput: document.getElementById("dxfOutput"),
+        downloadLink: document.getElementById("downloadLink"),
+        viewer: document.getElementById("viewer"),
+        viewerMessage: document.getElementById("viewerMessage"),
+    };
+
+    let selectedFile = null;
+    let wasmReady = false;
+    let downloadUrl = null;
+
+    const go = new Go();
+    const wasmReadyPromise = loadWasm();
+
+    elements.fileInput.addEventListener("change", (event) => {
+        selectedFile = event.target.files?.[0] || null;
+        elements.fileLabel.textContent = selectedFile?.name ?? "ファイルを選択";
+        updateConvertButton();
+    });
+
+    elements.convertBtn.addEventListener("click", async () => {
+        elements.convertBtn.disabled = true;
+        await convertFile();
+        updateConvertButton();
+    });
+
+    function setStatus(message, type = "info") {
+        elements.status.textContent = message;
+        elements.status.dataset.type = type;
+    }
+
+    function updateConvertButton() {
+        elements.convertBtn.disabled = !wasmReady || !selectedFile;
+    }
+
+    async function loadWasm() {
+        setStatus("WASM を読み込んでいます…");
+        try {
+            const result = await WebAssembly.instantiateStreaming(fetch("jww-dxf.wasm"), go.importObject).catch(async () => {
+                const response = await fetch("jww-dxf.wasm");
+                const bytes = await response.arrayBuffer();
+                return WebAssembly.instantiate(bytes, go.importObject);
+            });
+            go.run(result.instance);
+            wasmReady = true;
+            setStatus("WASM がロードされました。JWW ファイルを選択してください。", "success");
+            updateConvertButton();
+        } catch (error) {
+            console.error(error);
+            setStatus(`WASM のロードに失敗しました: ${error.message}`, "error");
+        }
+    }
+
+    async function convertFile() {
+        if (!selectedFile) {
+            alert("JWW ファイルを選択してください。");
+            return;
+        }
+
+        await wasmReadyPromise;
+        if (!wasmReady) {
+            alert("WASM のロードに失敗しています。ページを再読み込みしてください。");
+            return;
+        }
+
+        try {
+            setStatus("JWW を読み込み中…");
+            const buffer = await selectedFile.arrayBuffer();
+            const bytes = new Uint8Array(buffer);
+
+            const dxfDocResult = jwwToDxf(bytes);
+            if (!dxfDocResult.ok) {
+                throw new Error(dxfDocResult.error);
+            }
+            const doc = JSON.parse(dxfDocResult.data);
+            updateMeta(doc);
+
+            setStatus("DXF を生成しています…");
+            const dxfStringResult = jwwToDxfString(bytes);
+            if (!dxfStringResult.ok) {
+                throw new Error(dxfStringResult.error);
+            }
+
+            const dxfString = dxfStringResult.data;
+            elements.dxfOutput.value = dxfString;
+            updateDownloadLink(dxfString);
+            renderPreview(dxfString);
+            setStatus("DXF を生成しました。プレビューとダウンロードが利用できます。", "success");
+        } catch (error) {
+            console.error(error);
+            setStatus(`変換に失敗しました: ${error.message}`, "error");
+            elements.viewer.innerHTML = "";
+            elements.viewerMessage.textContent = "プレビューを表示できませんでした。";
+            elements.downloadLink.classList.add("disabled");
+            elements.downloadLink.setAttribute("aria-disabled", "true");
+            elements.downloadLink.removeAttribute("href");
+        }
+    }
+
+    function updateMeta(doc) {
+        const entries = [
+            { label: "レイヤー数", value: doc?.Layers?.length ?? 0 },
+            { label: "エンティティ数", value: doc?.Entities?.length ?? 0 },
+            { label: "ブロック数", value: doc?.Blocks?.length ?? 0 },
+        ];
+
+        elements.meta.innerHTML = entries
+            .map(
+                (entry) =>
+                    `<div><dt>${entry.label}</dt><dd>${entry.value.toLocaleString()}</dd></div>`
+            )
+            .join("");
+    }
+
+    function updateDownloadLink(dxfString) {
+        if (downloadUrl) {
+            URL.revokeObjectURL(downloadUrl);
+        }
+        const blob = new Blob([dxfString], { type: "application/dxf" });
+        downloadUrl = URL.createObjectURL(blob);
+
+        const filename = selectedFile?.name?.replace(/\.jww$/i, "") || "output";
+        elements.downloadLink.href = downloadUrl;
+        elements.downloadLink.download = `${filename}.dxf`;
+        elements.downloadLink.classList.remove("disabled");
+        elements.downloadLink.setAttribute("aria-disabled", "false");
+    }
+
+    function renderPreview(dxfString) {
+        elements.viewer.innerHTML = "";
+        elements.viewerMessage.textContent = "プレビューを準備しています…";
+
+        if (!window.DxfParser || !window.ThreeDxf || !window.THREE) {
+            elements.viewerMessage.textContent =
+                "プレビューライブラリを読み込めませんでした。ネットワーク接続を確認してください。";
+            return;
+        }
+
+        try {
+            const parser = new window.DxfParser();
+            const parsed = parser.parseSync(dxfString);
+            const width = elements.viewer.clientWidth || 640;
+            const height = elements.viewer.clientHeight || 480;
+            const viewer = new window.ThreeDxf.Viewer(parsed, elements.viewer, width, height);
+            viewer.render();
+            elements.viewerMessage.textContent = "右クリックでパン、マウスホイールでズームできます。";
+        } catch (error) {
+            console.error(error);
+            elements.viewerMessage.textContent = `DXF プレビューの生成に失敗しました: ${error.message}`;
+        }
+    }
+})();

--- a/wasm/example.html
+++ b/wasm/example.html
@@ -2,68 +2,87 @@
 <html lang="ja">
 <head>
     <meta charset="UTF-8">
-    <title>JWW to DXF Converter</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>JWW → DXF (WASM)</title>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1>JWW to DXF Converter</h1>
-    <input type="file" id="fileInput" accept=".jww">
-    <button id="convertBtn" disabled>DXFに変換</button>
-    <pre id="output"></pre>
+    <header class="page-header">
+        <div>
+            <p class="eyebrow">JWW to DXF / WebAssembly</p>
+            <h1>ブラウザで JWW を読み込み、DXF をプレビュー &amp; ダウンロード</h1>
+            <p class="lede">JWW ファイルをアップロードすると、WASM で変換した DXF をプレビュー表示し、内容を確認したままダウンロードできます。</p>
+        </div>
+        <a class="ghost" href="https://github.com/f4ah6o/jww-dxf" target="_blank" rel="noreferrer">GitHub</a>
+    </header>
 
-    <!-- Go WASM support script (必須) -->
+    <main class="layout">
+        <section class="card">
+            <div class="card-header">
+                <div>
+                    <p class="eyebrow">Step 1</p>
+                    <h2>JWW ファイルをアップロード</h2>
+                </div>
+                <div class="status" id="status">WASM を読み込んでいます…</div>
+            </div>
+            <div class="upload">
+                <label class="file-input">
+                    <input type="file" id="fileInput" accept=".jww">
+                    <span id="fileLabel">ファイルを選択</span>
+                </label>
+                <button id="convertBtn" disabled>DXF に変換</button>
+            </div>
+            <p class="hint">WASM がロードされると変換ボタンが有効になります。</p>
+            <dl class="meta" id="meta">
+                <div>
+                    <dt>レイヤー数</dt>
+                    <dd>—</dd>
+                </div>
+                <div>
+                    <dt>エンティティ数</dt>
+                    <dd>—</dd>
+                </div>
+                <div>
+                    <dt>ブロック数</dt>
+                    <dd>—</dd>
+                </div>
+            </dl>
+        </section>
+
+        <section class="card">
+            <div class="card-header">
+                <div>
+                    <p class="eyebrow">Step 2</p>
+                    <h2>DXF をプレビュー</h2>
+                </div>
+                <span class="badge">3D パン/ズーム対応</span>
+            </div>
+            <div id="viewer" class="viewer">
+                <div class="viewer-message" id="viewerMessage">DXF を読み込むとここに描画されます。右クリックでパン、マウスホイールでズームできます。</div>
+            </div>
+            <p class="hint">プレビューには <a href="https://github.com/gdsestimating/three-dxf" target="_blank" rel="noreferrer">three-dxf</a> と <a href="https://github.com/gdsestimating/dxf-parser" target="_blank" rel="noreferrer">dxf-parser</a> を使用しています。</p>
+        </section>
+
+        <section class="card">
+            <div class="card-header">
+                <div>
+                    <p class="eyebrow">Step 3</p>
+                    <h2>DXF 内容を確認・ダウンロード</h2>
+                </div>
+                <a id="downloadLink" class="ghost disabled" aria-disabled="true">DXF をダウンロード</a>
+            </div>
+            <p class="hint">DXF 文字列をそのままコピーすることもできます。</p>
+            <textarea id="dxfOutput" readonly spellcheck="false" placeholder="DXF 出力がここに表示されます"></textarea>
+        </section>
+    </main>
+
+    <!-- Go WASM runtime -->
     <script src="wasm_exec.js"></script>
-    <script>
-        const go = new Go();
-        
-        // WASMモジュールをロード
-        WebAssembly.instantiateStreaming(fetch("jww.wasm"), go.importObject)
-            .then((result) => {
-                go.run(result.instance);
-                console.log("WASM loaded! Available functions:", 
-                    "jwwParse, jwwToDxf, jwwToDxfString");
-                document.getElementById('convertBtn').disabled = false;
-            })
-            .catch((err) => {
-                console.error("WASM load failed:", err);
-            });
-
-        // ファイル選択処理
-        let selectedFile = null;
-        document.getElementById('fileInput').addEventListener('change', (e) => {
-            selectedFile = e.target.files[0];
-        });
-
-        // 変換処理
-        document.getElementById('convertBtn').addEventListener('click', async () => {
-            if (!selectedFile) {
-                alert('JWWファイルを選択してください');
-                return;
-            }
-
-            // ファイルをUint8Arrayとして読み込み
-            const arrayBuffer = await selectedFile.arrayBuffer();
-            const uint8Array = new Uint8Array(arrayBuffer);
-
-            // WASMの関数を呼び出し
-            const result = jwwToDxfString(uint8Array);
-            
-            if (result.ok) {
-                // 成功：DXF文字列を表示/ダウンロード
-                document.getElementById('output').textContent = result.data;
-                
-                // DXFファイルとしてダウンロード
-                const blob = new Blob([result.data], { type: 'text/plain' });
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = selectedFile.name.replace('.jww', '.dxf');
-                a.click();
-            } else {
-                // エラー
-                document.getElementById('output').textContent = 
-                    'Error: ' + result.error;
-            }
-        });
-    </script>
+    <!-- DXF viewer dependencies -->
+    <script src="https://cdn.jsdelivr.net/npm/dxf-parser@4.9.0/dist/dxf-parser.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/three-dxf@0.0.7/build/three-dxf.js"></script>
+    <!-- App logic -->
+    <script src="app.js"></script>
 </body>
 </html>

--- a/wasm/styles.css
+++ b/wasm/styles.css
@@ -1,0 +1,266 @@
+* {
+    box-sizing: border-box;
+}
+
+:root {
+    color-scheme: light dark;
+    --border: rgba(0, 0, 0, 0.1);
+    --muted: rgba(0, 0, 0, 0.6);
+    --radius: 14px;
+    --gap: 18px;
+    --card-padding: 20px;
+    --bg: #f5f5f5;
+    --card-bg: #fff;
+    --accent: #2f80ed;
+    --accent-weak: #e9f2ff;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --border: rgba(255, 255, 255, 0.08);
+        --muted: rgba(255, 255, 255, 0.7);
+        --bg: #0f1117;
+        --card-bg: #161921;
+        --accent: #5aa5ff;
+        --accent-weak: #16263c;
+    }
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: radial-gradient(circle at 15% 20%, rgba(47, 128, 237, 0.08), transparent 25%),
+        radial-gradient(circle at 85% 10%, rgba(255, 99, 71, 0.05), transparent 22%),
+        var(--bg);
+    color: #111;
+    min-height: 100vh;
+    padding: 32px;
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: 20px;
+    }
+}
+
+.page-header {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--gap);
+    align-items: center;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    font-size: 12px;
+    color: var(--muted);
+    margin: 0 0 4px;
+}
+
+h1 {
+    margin: 0 0 8px;
+    font-size: clamp(22px, 3vw, 28px);
+}
+
+.lede {
+    margin: 0;
+    color: var(--muted);
+    max-width: 740px;
+}
+
+.ghost {
+    border: 1px solid var(--border);
+    color: inherit;
+    padding: 10px 14px;
+    border-radius: 999px;
+    text-decoration: none;
+    transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.ghost:hover {
+    border-color: rgba(47, 128, 237, 0.4);
+    background: var(--accent-weak);
+}
+
+.layout {
+    display: grid;
+    gap: var(--gap);
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--card-padding);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.status {
+    font-size: 14px;
+    color: var(--muted);
+    background: var(--accent-weak);
+    padding: 8px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+}
+
+.upload {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.file-input {
+    border: 1px dashed var(--border);
+    padding: 12px 14px;
+    border-radius: 12px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(0, 0, 0, 0.02);
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.file-input:hover {
+    border-color: rgba(47, 128, 237, 0.5);
+    background: var(--accent-weak);
+}
+
+.file-input input {
+    display: none;
+}
+
+button {
+    border: none;
+    background: var(--accent);
+    color: #fff;
+    padding: 12px 18px;
+    border-radius: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.1s ease, box-shadow 0.1s ease, opacity 0.2s ease;
+    box-shadow: 0 8px 18px rgba(47, 128, 237, 0.35);
+}
+
+button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+    transform: none;
+}
+
+button:not(:disabled):active {
+    transform: translateY(1px);
+    box-shadow: 0 6px 14px rgba(47, 128, 237, 0.35);
+}
+
+.hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 14px;
+}
+
+.meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 12px;
+    margin: 0;
+}
+
+.meta div {
+    background: rgba(0, 0, 0, 0.02);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.meta dt {
+    font-size: 12px;
+    color: var(--muted);
+    margin: 0 0 4px;
+}
+
+.meta dd {
+    margin: 0;
+    font-weight: 700;
+}
+
+.viewer {
+    position: relative;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    min-height: 420px;
+    background: radial-gradient(circle at 20% 30%, rgba(47, 128, 237, 0.06), transparent 32%),
+        radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.05), transparent 26%),
+        var(--card-bg);
+    overflow: hidden;
+}
+
+.viewer canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+}
+
+.viewer-message {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    text-align: center;
+    padding: 20px;
+    pointer-events: none;
+}
+
+.badge {
+    background: var(--accent-weak);
+    color: var(--accent);
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    border: 1px solid rgba(47, 128, 237, 0.3);
+}
+
+#dxfOutput {
+    width: 100%;
+    min-height: 240px;
+    resize: vertical;
+    padding: 12px;
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    background: rgba(0, 0, 0, 0.02);
+    color: inherit;
+    font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
+#downloadLink {
+    cursor: pointer;
+}
+
+#downloadLink.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+a {
+    color: var(--accent);
+}


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that builds the WASM assets and publishes the demo
- refresh the browser example to upload JWW files, preview DXF output, and download the result
- add styling/JS helpers and make wasm_exec.js copying compatible with the current Go toolchain layout

## Testing
- make dist
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943c45a0e3c832fadc603c79766d7df)