### PR TITLE
Add workflow to refresh gh-pages via PR

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy WASM demo to GitHub Pages
+name: Publish GitHub Pages via PR
 
 on:
   push:
@@ -15,20 +15,21 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+  pull-requests: write
 
 concurrency:
-  group: "pages"
+  group: "pages-pr"
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-propose:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -38,21 +39,43 @@ jobs:
       - name: Build WebAssembly assets
         run: make dist
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
+      - name: Archive build output
+        run: cp -r dist ../pages-dist
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Switch to gh-pages base tree
+        run: |
+          git fetch origin gh-pages || true
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git switch --force-create gh-pages-work origin/gh-pages
+          else
+            git switch --orphan gh-pages-work
+          fi
+
+      - name: Prepare gh-pages branch content
+        run: |
+          shopt -s dotglob
+          for path in *; do
+            if [ "$path" != ".git" ]; then
+              rm -rf "$path"
+            fi
+          done
+          cp -a ../pages-dist/. .
+          touch .nojekyll
+          cat <<'README' > README.md
+# GitHub Pages artifacts
+
+このブランチはGitHub Pagesの公開用成果物のみを含みます。
+mainブランチの更新時に自動生成されるdistディレクトリの内容を配置しています。
+README
+
+      - name: Create pull request to update gh-pages
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update GitHub Pages content"
+          title: "Update GitHub Pages content"
+          body: |
+            Automated PR to refresh the GitHub Pages branch with the latest build from main.
+          base: gh-pages
+          branch: update/gh-pages
+          delete-branch: true


### PR DESCRIPTION
## Summary
- replace the Pages deploy workflow with a job that builds the WASM demo and proposes updates to the gh-pages branch
- prepare the gh-pages branch with only generated site artifacts (including .nojekyll and README) and open an automated PR

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e0750c3c832fa378dbf043790240)