### PR TITLE
Fix gh-pages workflow YAML indentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -62,11 +62,11 @@ jobs:
           cp -a ../pages-dist/. .
           touch .nojekyll
           cat <<'README' > README.md
-# GitHub Pages artifacts
-
-このブランチはGitHub Pagesの公開用成果物のみを含みます。
-mainブランチの更新時に自動生成されるdistディレクトリの内容を配置しています。
-README
+          # GitHub Pages artifacts
+          
+          このブランチはGitHub Pagesの公開用成果物のみを含みます。
+          mainブランチの更新時に自動生成されるdistディレクトリの内容を配置しています。
+          README
 
       - name: Create pull request to update gh-pages
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
## Summary
- fix the README heredoc indentation in the gh-pages workflow so the YAML parses correctly

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943e4a43570832f8220a3e371052659)