### PR TITLE
Add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,43 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: npm/package-lock.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        working-directory: npm
+        run: npm ci
+
+      - name: Build package
+        working-directory: npm
+        run: npm run build
+
+      - name: Publish package
+        working-directory: npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to publish the npm package on releases or manual runs
- include Go and Node setup, cached npm installs, build, and npm publish steps using NPM_TOKEN

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69447cabb524832f82c42dea83b866c1)